### PR TITLE
Localized Info.plist

### DIFF
--- a/Brand/iOCNotes.plist
+++ b/Brand/iOCNotes.plist
@@ -88,7 +88,7 @@
 		<true/>
 	</dict>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>NextcloudNotes needs local network access if your server is hosted locally</string>
+	<string>Nextcloud Notes needs local network access if your server is hosted locally</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/Source/cs.lproj/InfoPlist.strings
+++ b/Source/cs.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+"NSLocalNetworkUsageDescription" = "Nextcloud Notes needs local network access if your server is hosted locally";

--- a/Source/de.lproj/InfoPlist.strings
+++ b/Source/de.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+"NSLocalNetworkUsageDescription" = "Nextcloud Notes needs local network access if your server is hosted locally";

--- a/Source/en.lproj/InfoPlist.strings
+++ b/Source/en.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+"NSLocalNetworkUsageDescription" = "Nextcloud Notes needs local network access if your server is hosted locally";

--- a/Source/fr.lproj/InfoPlist.strings
+++ b/Source/fr.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+"NSLocalNetworkUsageDescription" = "Nextcloud Notes needs local network access if your server is hosted locally";

--- a/Source/ko.lproj/InfoPlist.strings
+++ b/Source/ko.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+"NSLocalNetworkUsageDescription" = "Nextcloud Notes needs local network access if your server is hosted locally";


### PR DESCRIPTION
Fixed a typo in `NSLocalNetworkUsageDescription` and added it to previously empty localizable strings resource file.