### PR TITLE
Fix #98: Server port considered for capability check.

### DIFF
--- a/Nextcloud/Networking/NCService.swift
+++ b/Nextcloud/Networking/NCService.swift
@@ -45,7 +45,12 @@ class NCService: NSObject {
               let host = server.host
         else { return }
 
-        let urlBase = scheme + "://" + host
+        var urlBase = scheme + "://" + host
+
+        if let port = server.port {
+            urlBase = "\(urlBase):\(port)"
+        }
+
         let user = KeychainHelper.username
         let password = KeychainHelper.password
         let account: String = "\(user) \(urlBase)"


### PR DESCRIPTION
Makes the login work with server address like `http://192.168.178:45:8080`. Without this, explicit port specifications are not supported and result in error alerts of failed requests.