### PR TITLE
 Fix search bar getting hidden after closing a note

### DIFF
--- a/iOCNotes/Views/NotesView.swift
+++ b/iOCNotes/Views/NotesView.swift
@@ -9,10 +9,12 @@ import SwiftUI
 ///
 struct NotesView: View {
     @State private var addNote = false
+    @State private var searchText = ""
 
     var body: some View {
-        NotesTableViewControllerRepresentable(addNote: $addNote)
+        NotesTableViewControllerRepresentable(addNote: $addNote, searchText: $searchText)
             .ignoresSafeArea(.all)
+            .searchable(text: $searchText)
             .toolbar {
                 Button {
                     addNote = true


### PR DESCRIPTION


Search bar was attached to the header view, which caused it to hide when closing a note. Now it’s part of SwiftUI